### PR TITLE
change upload url to https

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -493,7 +493,7 @@ Wbpd.prototype={
                     }
                 }
             };
-            xhr.open('POST', 'http://picupload.service.weibo.com/interface/pic_upload.php?ori=1&mime=image%2Fjpeg&data=base64&url=0&markpos=1&logo=&nick=0&marks=1&app=miniblog');
+            xhr.open('POST', 'https://picupload.weibo.com/interface/pic_upload.php?ori=1&mime=image%2Fjpeg&data=base64&url=0&markpos=1&logo=&nick=0&marks=1&app=miniblog');
             xhr.send(data);
         };
     },


### PR DESCRIPTION
fix cannot upload issue by changing upload url to https

This should fix #135 #134 #133 #132

It seems picupload.service.weibo.com:80 denied request by `Connect Reset`

Changing to `https` also increase account security.