### PR TITLE
修复微博防外链的问题

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -230,10 +230,10 @@ function pid2url(params, type) {
 		type = 'large';
 	if (params.pid[9] == 'w') {
 		zone = (crc32(params.pid) & 3) + 1;
-		url = 'http://ww' + zone + '.sinaimg.cn/' + type + '/' + params.pid;
+		url = 'http://tva' + zone + '.sinaimg.cn/' + type + '/' + params.pid;
 	} else {
 		zone = ((params.pid.substr(-2, 2), 16) & 0xf) + 1;
-		url = 'http://ss' + zone + '.sinaimg.cn/' + type + '/' + params.pid;
+		url = 'http://tva' + zone + '.sinaimg.cn/' + type + '/' + params.pid;
 	}
 	return url + params.ext;
 }

--- a/js/popup.js
+++ b/js/popup.js
@@ -1,8 +1,8 @@
 var global_pid = "";
 var storageData = localStorage.weiboData ? JSON.parse(localStorage.weiboData) : [];
 var https = localStorage.is_https ? JSON.parse(localStorage.is_https) : $("#https").is(':checked');
-var http_pre  = "http://ww";
-var https_pre = "https://wx";
+var http_pre  = "http://tva";
+var https_pre = "https://tva";
 
 
 var Wbpd = Wbpd || {};


### PR DESCRIPTION
之前用的 http://ww 和 https://wx 不能被作为外链访问，因此修改成了tva。
Fixes #160 #153 #151 #131 #125 #122 #120 